### PR TITLE
Add ability to drop multiples

### DIFF
--- a/libs/inventory/src/Inventory.py
+++ b/libs/inventory/src/Inventory.py
@@ -255,7 +255,8 @@ class Items:
         except ValueError:
             quantity = 1
         try:
-            Factory(item, template = f"{item}.py")
+            for _ in range(quantity - 1):
+                Factory(item, template = f"{item}.py")
             list.add(item, 0 - int(quantity))
         except:
             pass


### PR DESCRIPTION
Consistent with other revisions to `inventory` commands, this PR adds the ability to drop multiple items. By default it assumes only `1` copy.