### PR TITLE
Adding updated requirements for worldlib

### DIFF
--- a/libs/worldlib/requirements.txt
+++ b/libs/worldlib/requirements.txt
@@ -1,2 +1,2 @@
-inventory==0.1
+inventory==0.2
 narrator==0.1


### PR DESCRIPTION
Required patch for installing `worldlib` now that we've made `inventory` an `0.2`.