### PR TITLE
Fixing solar power time bug

### DIFF
--- a/libs/resources/src/renewable.py
+++ b/libs/resources/src/renewable.py
@@ -38,7 +38,9 @@ class Solar(Inexhaustible):
         self.__calc_wattage()
 
     def __calc_wattage(self):
+        if not self.CLIMATE.sunny:
+            self.wattage = 0
         self.power = (self.wattage * .016) / 1000
         self.generation(type = "Solar")
-        with CONSOLE.status("Generating solar power...", spinner = "weather"):
+        with CONSOLE.status("Generating solar power...", spinner = "moon"):
             sleep(1)


### PR DESCRIPTION
Fixes bug in `renewables` that didn't `0` out the power when the `sunny` boolean was tripped.