### PR TITLE
Fixing templating system

### DIFF
--- a/libs/inventory/inventory/Item.py
+++ b/libs/inventory/inventory/Item.py
@@ -95,13 +95,16 @@ class Factory:
     def load_template(self, template: str = ""):
         if not template:
             return Template
-        template = template.split(".py")[0]
-        inv_path = os.path.expanduser(
-            Config.values["INV_PATH"]
-        )
+        filepath = os.path.dirname(template)
+        template = os.path.basename(template)
+        if not filepath:
+            filepath = os.path.expanduser(
+                Config.values["INV_PATH"]
+            )
+        print(filepath, template)
         spec = util.spec_from_file_location(
             template,
-            f"{inv_path}/{template}.py"
+            f"{filepath}/{template}"
         )
         mod = util.module_from_spec(spec)
         return mod


### PR DESCRIPTION
`inventory` templating system didn't account for custom item files in the way originally planned. This has been fixed.